### PR TITLE
Update em_margin mixin

### DIFF
--- a/helpers/_mixins.scss
+++ b/helpers/_mixins.scss
@@ -49,7 +49,7 @@
 	min-height: #{$px / $default}em; 
 }
 
-@mixin em_padding($top:0,$right:0,$bot:$top,$left:$right, $default: $default-fontsize) { 
+@mixin em_padding($top:0,$right:$top,$bot:$top,$left:$right, $default: $default-fontsize) { 
 	padding: #{$top / $default}em #{$right / $default}em #{$bot / $default}em #{$left / $default}em 
 }
 @mixin em_fontsize($px) { 
@@ -62,7 +62,7 @@
 	line-height: #{$px / $default}em; 
 }
 
-@mixin em_margin($top: 0, $right: 0, $bot: $top, $left: $right, $default: $default-fontsize) {
+@mixin em_margin($top: 0, $right: $top, $bot: $top, $left: $right, $default: $default-fontsize) {
 	@if $top == auto {
 		$top : auto
 	} @else {


### PR DESCRIPTION
Changes: 
- updated the `em_margin` mixin to accept `auto` as an argument. 
- added mixins for `em_margin_top/right/bottom/left` for situations where you need to alter a single margin without affecting previously set ones.
- Changed the layout of the other mixins. I think this makes it easier to read. Feel free to call me crazy. I'll respond with : 
  ![boxer](https://cloud.githubusercontent.com/assets/4861202/5208146/67eea83a-757f-11e4-8345-290554961759.jpg)
